### PR TITLE
FB issues added on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,13 @@ SyntaxError: Unexpected token function"
 Async functions are not supported by Node versions older than version 7.6
 
 At package.json we specified:  node v.8.1.4
+
+10.25
+Facebook authorization on local machine
+- register a developer account on developers.facebook.com
+- Settings - Site URL - http://localhost:3000/
+- Facebook Login - Valid OAuth redirect URIs - http://localhost:3000/
+- providers.json : replace "clientID" "clientSecret" in "facebook-link" "facebook-login" with yours in settings
+
+error: Can't Load URL: The domain of this URL isn't included in the app's domains.
+Fixed: Facebook Login - Client OAuth Settings - Use Strict Mode for Redirect URIs - No

--- a/providers.json
+++ b/providers.json
@@ -18,8 +18,8 @@
       "timezone",      
       "email"       
     ],
-    "clientID": "291799974652971",
-    "clientSecret": "7473cfc3bc4cb7dcafe8b6c409e02770",
+    "clientID": "138437403572783",
+    "clientSecret": "e309b1c7adc016cc65f40eed87bc4611",
     "callbackURL": "/auth/facebook/callback",
     "authPath": "/auth/facebook",
     "callbackPath": "/auth/facebook/callback",
@@ -31,8 +31,8 @@
   "facebook-link": {
     "provider": "facebook",
     "module": "passport-facebook",
-    "clientID": "291799974652971",
-    "clientSecret": "7473cfc3bc4cb7dcafe8b6c409e02770",
+    "clientID": "138437403572783",
+    "clientSecret": "e309b1c7adc016cc65f40eed87bc4611",
     "callbackURL": "/link/facebook/callback",
     "authPath": "/link/facebook",
     "callbackPath": "/link/facebook/callback",


### PR DESCRIPTION
### Description

Added FB issues to readme.
The ID and secret in providers.json are replaced by my facebook developer account to test on local machine.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
